### PR TITLE
Escape single quote correctly.

### DIFF
--- a/faraday-curl.gemspec
+++ b/faraday-curl.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 0.9.0"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'faraday_middleware', ">= 0.9.0"

--- a/lib/faraday/curl/middleware.rb
+++ b/lib/faraday/curl/middleware.rb
@@ -42,7 +42,7 @@ module Faraday
       end
 
       def quote(value)
-        value.gsub("'", "\\'")
+        value.gsub("'") { "\\'" }
       end
     end
   end

--- a/lib/faraday/curl/middleware.rb
+++ b/lib/faraday/curl/middleware.rb
@@ -42,7 +42,7 @@ module Faraday
       end
 
       def quote(value)
-        value.gsub("'") { "\\'" }
+        value.gsub("'") { "'\\''" }
       end
     end
   end

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -49,4 +49,12 @@ describe Faraday::Curl::Middleware do
     match_command(response, "PUT", "-H 'Content-Type: application/x-www-form-urlencoded'", "-d 'age=50&name%5B%5D=john&name%5B%5D=doe'", '"http://example.com/echo"')
   end
 
+  it 'should escape headers' do
+    connection = create_connection
+    response = connection.get( "/echo" ) do |request|
+      request.headers["Cookies"] = "exa'm'ple"
+    end
+    match_command(response, "GET", "-H 'Cookies: exa\\'m\\'ple'", '"http://example.com/echo"')
+  end
+
 end

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -52,9 +52,9 @@ describe Faraday::Curl::Middleware do
   it 'should escape headers' do
     connection = create_connection
     response = connection.get( "/echo" ) do |request|
-      request.headers["Cookies"] = "exa'm'ple"
+      request.headers["Cookies"] = "exa'mple"
     end
-    match_command(response, "GET", "-H 'Cookies: exa\\'m\\'ple'", '"http://example.com/echo"')
+    match_command(response, "GET", "-H 'Cookies: exa'\\''mple'", '"http://example.com/echo"')
   end
 
 end

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -8,7 +8,7 @@ Faraday::Request.register_middleware( :url_encoded => Faraday::Request::UrlEncod
 
 describe Faraday::Curl::Middleware do
 
-  let(:version) { "-H 'User-Agent: Faraday v0.9.0'" }
+  let(:version) { "-H 'User-Agent: Faraday v#{Faraday::VERSION}'" }
 
   def create_connection( *request_middlewares )
     Faraday.new( :url => 'http://example.com' ) do |b|


### PR DESCRIPTION
`\\'` has a special meaning in `String#gsub`'s replacement string.

https://docs.ruby-lang.org/en/2.6.0/String.html#method-i-gsub

> If replacement is a String it will be substituted for the matched text. It may contain back-references to the pattern's capture groups of the form \\d, where d is a group number, or \\k<n>, where n is a group name. If it is a double-quoted string, both back-references must be preceded by an additional backslash. However, within replacement the special match variables, such as $&, will not refer to the current match.

So `\\'` is `$'`.

https://docs.ruby-lang.org/en/2.6.0/globals_rdoc.html

> $'
> The string to the right of the last successful match.

It works like this.

```
irb> "exampl'e".gsub("'", "\\'")
=> "examplee"
irb> "examp'le".gsub("'", "\\'")
=> "examplele"
```

It's implemented in https://github.com/ruby/ruby/blob/3df37259d81d9fc71f8b4f0b8d45dc9d0af81ab4/re.c#L3887 since before 1998.

So current `Faraday::Curl#quote` dosen't work correctly.

In this patch I use a block argument.

```
irb> "exampl'e".gsub("'") { "\\'" }
=> "exampl\\'e"
```